### PR TITLE
Update comfortclipboardpro.nuspec to remove www.

### DIFF
--- a/comfortclipboardpro/comfortclipboardpro.nuspec
+++ b/comfortclipboardpro/comfortclipboardpro.nuspec
@@ -6,29 +6,29 @@
     <owners>Nicola Farina</owners>
     <title>Comfort Clipboard Pro</title>
     <authors>Comfort Software Group</authors>
-    <projectUrl>https://www.comfort-software.com/clipboard-manager/</projectUrl>
+    <projectUrl>https://comfort-software.com/clipboard-manager/</projectUrl>
     <iconUrl>https://cdn.statically.io/gh/nicolafarina/chocolatey-packages/401d100c/comfortclipboardpro/CC-Icon-256x256.png</iconUrl>
     <copyright>Copyright © Comfort Software Group</copyright>
-    <licenseUrl>https://www.comfort-software.com/en/clipboard-manager/license-agreement/</licenseUrl>
+    <licenseUrl>https://comfort-software.com/en/clipboard-manager/license-agreement/</licenseUrl>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
 	<packageSourceUrl>https://github.com/nicolafarina/chocolatey-packages/tree/master/comfortclipboardpro</packageSourceUrl>
-    <docsUrl>https://www.comfort-software.com/clipboard/help/</docsUrl>
+    <docsUrl>https://comfort-software.com/clipboard/help/</docsUrl>
     <tags>comfortclipboardpro comfortclipboard clipboardmanager clipboard manager trial</tags>
     <summary>Comfort Clipboard Pro is a clipboard manager</summary>
     <description>Comfort Clipboard Pro keeps the clipboard history that you can use to paste any selected fragment again. Advanced features include several actions with fragments: automatically saving, pasting in any available format, previewing in a comfortable window (images too) and displaying additional informations.
 	
 ![Comfort Clipboard Pro](https://cdn.statically.io/gh/nicolafarina/chocolatey-packages/401d100c/comfortclipboardpro/screenshot_01.png)
 	
-[More screenshots](https://www.comfort-software.com/clipboard-manager/)
+[More screenshots](https://comfort-software.com/clipboard-manager/)
 	
 ### Commercial software
 Setup starts you with a trial version that can be upgrade to perpetual adding a purchased license key.
-You can [buy here](https://www.comfort-software.com/en/clipboard-manager/).
+You can [buy here](https://comfort-software.com/en/clipboard-manager/).
 
 ### New versions possible checksums error (no panic)
 **Authors do not provide specific URLs for each version, so the download URL in this package will always download the latest version. Please be patient if you get checksums failure, probably due to lag between official release and new Chocolatey package. I'll try to update as soon as possible, but you can try --ignore-checksums parameter to bypass the error or, better, warn me in comments section here or by opening a GitHub issue. Thank you.**
 	</description>
-    <releaseNotes>https://www.comfort-software.com/clipboard-manager/version-history/</releaseNotes>  
+    <releaseNotes>https://comfort-software.com/clipboard-manager/version-history/</releaseNotes>  
   </metadata>
   <files>
     <file src="tools\**" target="tools" />


### PR DESCRIPTION
www.comfort-software.com no longer validates the certificate.  The new certificate was pushed on 11/2023 and only includes comfort-software.com.  The www.comfort-software.com is no longer included.  Due to the certificate failing, users were no longer able to download the software so the install was broken.